### PR TITLE
fix: add missing comma in app.module.ts

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -28,7 +28,7 @@ import { AssessmentModule } from './modules/assessment/assessment.module';
     FamilyMemberModule,
     AddressModule,
     LevelModule,
-    EnrollmentModule
+    EnrollmentModule,
     AssessmentModule
   ],
 })


### PR DESCRIPTION
## Description
Fixes a syntax error caused by a missing comma in `app.module.ts` that caused the PR build to fail after merging to `develop`.

## Type of Change

<!-- Check all that apply -->
- [x] Bug fix
- [x] Build may be affected
-
## Changed

- [x] Bugfix for develop (`app.module.ts` syntax issue)

## Additional Notes
No functional changes; this PR only fixes a minor syntax issue that caused the previous build to fail.
