### PR TITLE
feat(activity): add activity management module

### DIFF
--- a/docs/API_ATIVIDADES.md
+++ b/docs/API_ATIVIDADES.md
@@ -1,0 +1,144 @@
+# API de Atividades
+
+Esta documentacao descreve como criar, listar e atualizar atividades no catalogo utilizado pelas turmas.
+
+## Endpoints
+
+### POST /activities
+Cria uma nova atividade.
+
+#### Request
+```json
+{
+  "name": "Esporte"
+}
+```
+
+#### Resposta de sucesso (201 Created)
+```json
+{
+  "id": 1,
+  "name": "Esporte"
+}
+```
+
+#### Erros possiveis
+- `400 Bad Request` - campo `name` ausente, vazio ou somente espacos.
+- `409 Conflict` - ja existe uma atividade com o mesmo `name`.
+
+#### Exemplos de teste
+```bash
+# Fluxo ideal
+curl -X POST http://localhost:3000/activities \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Esporte" }'
+
+# Nome duplicado
+curl -X POST http://localhost:3000/activities \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Esporte" }'
+
+# Nome invalido
+curl -X POST http://localhost:3000/activities \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "   " }'
+```
+
+#### BDD
+- **Scenario - Successful Create**  
+  Given um payload com `"name": "Esporte"`  
+  When o cliente envia `POST /activities`  
+  Then o sistema cria a atividade e retorna `201` com `{ id, name }`
+
+- **Scenario - Duplicate Name**  
+  Given ja existe uma atividade `"Esporte"`  
+  When envia `POST /activities` com `"name": "Esporte"`  
+  Then retorna `409 Conflict`
+
+- **Scenario - Invalid Name**  
+  Given um payload com `"name": " "`  
+  When envia `POST /activities`  
+  Then retorna `400 Bad Request`
+
+---
+
+### GET /activities
+Lista todas as atividades cadastradas.
+
+#### Resposta de sucesso (200 OK)
+```json
+[
+  { "id": 1, "name": "Esporte" },
+  { "id": 2, "name": "Artes" }
+]
+```
+
+#### BDD
+- **Scenario - List All**  
+  Given existem atividades cadastradas  
+  When chama `GET /activities`  
+  Then retorna `200` com a lista de `{ id, name }`
+
+---
+
+### PATCH /activities/{id}
+Atualiza uma atividade existente.
+
+#### Request
+```json
+{
+  "name": "Esportes"
+}
+```
+
+#### Resposta de sucesso (200 OK)
+```json
+{
+  "id": 1,
+  "name": "Esportes"
+}
+```
+
+#### Erros possiveis
+- `400 Bad Request` - campo `name` ausente, vazio ou somente espacos.
+- `404 Not Found` - atividade com o `id` informado nao existe.
+- `409 Conflict` - nome ja utilizado por outra atividade.
+
+#### Exemplos de teste
+```bash
+# Atualizacao bem-sucedida
+curl -X PATCH http://localhost:3000/activities/1 \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Esportes" }'
+
+# Nome duplicado
+curl -X PATCH http://localhost:3000/activities/1 \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "Artes" }'
+
+# Nome invalido
+curl -X PATCH http://localhost:3000/activities/1 \
+  -H "Content-Type: application/json" \
+  -d '{ "name": "   " }'
+```
+
+#### BDD
+- **Scenario - Successful Update**  
+  Given existe `Activity(id=1, name="Esporte")`  
+  When envia `PATCH /activities/1` com `{ "name": "Esportes" }`  
+  Then retorna `200` com `{ "id": 1, "name": "Esportes" }`
+
+- **Scenario - Duplicate Name**  
+  Given ja existe outra `Activity(name="Artes")`  
+  When atualiza `Activity(id=1)` para `{ "name": "Artes" }`  
+  Then retorna `409 Conflict`
+
+- **Scenario - Invalid Name**  
+  Given `Activity(id=1)`  
+  When envia `{ "name": " " }`  
+  Then retorna `400 Bad Request`
+
+---
+
+## Documentacao Swagger
+Depois de iniciar o servidor, a documentacao interativa fica disponivel em `http://localhost:3000/docs`.

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { LevelModule } from './modules/level/level.module';
 import { EnrollmentModule } from './modules/enrollment/enrollment.module';
 import { AssessmentModule } from './modules/assessment/assessment.module';
 import { ClassModule } from './modules/class/class.module';
+import { ActivityModule } from './modules/activity/activity.module';
 
 @Module({
   imports: [
@@ -31,7 +32,8 @@ import { ClassModule } from './modules/class/class.module';
     LevelModule,
     EnrollmentModule,
     AssessmentModule,
-    ClassModule
+    ClassModule,
+    ActivityModule
   ],
 })
 export class AppModule {}

--- a/src/modules/activity/activity.module.ts
+++ b/src/modules/activity/activity.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common";
+import { ActivityController } from "./presentation/activity.controller";
+import { ActivityService } from "./application/activity.service";
+import { ACTIVITY_REPOSITORY_TOKEN } from "./domain/activity-repository.interface";
+import { PrismaActivityRepository } from "./infrastructure/activity.repository";
+
+@Module({
+  controllers: [ActivityController],
+  providers: [
+    ActivityService,
+    {
+      provide: ACTIVITY_REPOSITORY_TOKEN,
+      useClass: PrismaActivityRepository,
+    },
+  ],
+  exports: [ActivityService, ACTIVITY_REPOSITORY_TOKEN],
+})
+export class ActivityModule {}

--- a/src/modules/activity/application/activity.response.dto.ts
+++ b/src/modules/activity/application/activity.response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class ActivityResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: "Unique identifier of the activity",
+  })
+  id!: number;
+
+  @ApiProperty({
+    example: "Esporte",
+    description: "Name of the activity",
+  })
+  name!: string;
+}

--- a/src/modules/activity/application/activity.service.ts
+++ b/src/modules/activity/application/activity.service.ts
@@ -1,0 +1,71 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import {
+  ACTIVITY_REPOSITORY_TOKEN,
+  IActivityRepository,
+} from "../domain/activity-repository.interface";
+import { CreateActivityRequestDto } from "./create-activity.request.dto";
+import { Activity } from "../domain/activity.entity";
+import { UpdateActivityDto } from "./update-activity.dto";
+
+@Injectable()
+export class ActivityService {
+  constructor(
+    @Inject(ACTIVITY_REPOSITORY_TOKEN)
+    private readonly activityRepository: IActivityRepository,
+  ) {}
+
+  async create(dto: CreateActivityRequestDto): Promise<Activity> {
+    const normalizedName = dto.name.trim();
+    if (!normalizedName) {
+      throw new BadRequestException("Name is required");
+    }
+
+    const existing = await this.activityRepository.findByName(normalizedName);
+    if (existing) {
+      throw new ConflictException(
+        `Activity name '${normalizedName}' is already in use.`,
+      );
+    }
+
+    const activity = new Activity(undefined, normalizedName);
+    return this.activityRepository.create(activity);
+  }
+
+  async findAll(): Promise<Activity[]> {
+    return this.activityRepository.findAll();
+  }
+
+  async update(id: number, dto: UpdateActivityDto): Promise<Activity> {
+    const existingActivity = await this.activityRepository.findById(id);
+    if (!existingActivity) {
+      throw new NotFoundException(`Activity with ID ${id} not found.`);
+    }
+
+    const normalizedName = dto.name.trim();
+    if (!normalizedName) {
+      throw new BadRequestException("Name is required");
+    }
+
+    const activityWithSameName =
+      await this.activityRepository.findByName(normalizedName);
+
+    if (
+      activityWithSameName &&
+      activityWithSameName.getId() !== existingActivity.getId()
+    ) {
+      throw new ConflictException(
+        `Activity name '${normalizedName}' is already in use.`,
+      );
+    }
+
+    existingActivity.setName(normalizedName);
+
+    return this.activityRepository.update(existingActivity);
+  }
+}

--- a/src/modules/activity/application/create-activity.request.dto.ts
+++ b/src/modules/activity/application/create-activity.request.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Transform } from "class-transformer";
+import { IsNotEmpty, IsString, MaxLength } from "class-validator";
+
+export class CreateActivityRequestDto {
+  @ApiProperty({
+    example: "Esporte",
+    description: "Unique name of the activity",
+    minLength: 1,
+    maxLength: 100,
+  })
+  @Transform(({ value }) =>
+    typeof value === "string" ? value.trim() : value,
+  )
+  @IsString({ message: "Name must be a string" })
+  @IsNotEmpty({ message: "Name is required" })
+  @MaxLength(100, { message: "Name must be at most 100 characters long" })
+  name!: string;
+}

--- a/src/modules/activity/application/update-activity.dto.ts
+++ b/src/modules/activity/application/update-activity.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Transform } from "class-transformer";
+import { IsNotEmpty, IsString, MaxLength } from "class-validator";
+
+export class UpdateActivityDto {
+  @ApiProperty({
+    example: "Esportes",
+    description: "Updated name of the activity",
+    minLength: 1,
+    maxLength: 100,
+  })
+  @Transform(({ value }) =>
+    typeof value === "string" ? value.trim() : value,
+  )
+  @IsString({ message: "Name must be a string" })
+  @IsNotEmpty({ message: "Name is required" })
+  @MaxLength(100, { message: "Name must be at most 100 characters long" })
+  name!: string;
+}

--- a/src/modules/activity/domain/activity-repository.interface.ts
+++ b/src/modules/activity/domain/activity-repository.interface.ts
@@ -1,0 +1,11 @@
+import { Activity } from "./activity.entity";
+
+export const ACTIVITY_REPOSITORY_TOKEN = "ActivityRepository";
+
+export interface IActivityRepository {
+  create(activity: Activity): Promise<Activity>;
+  findAll(): Promise<Activity[]>;
+  findById(id: number): Promise<Activity | null>;
+  findByName(name: string): Promise<Activity | null>;
+  update(activity: Activity): Promise<Activity>;
+}

--- a/src/modules/activity/domain/activity.entity.ts
+++ b/src/modules/activity/domain/activity.entity.ts
@@ -1,0 +1,18 @@
+export class Activity {
+  constructor(
+    private readonly id: number | undefined,
+    private name: string,
+  ) {}
+
+  getId(): number | undefined {
+    return this.id;
+  }
+
+  getName(): string {
+    return this.name;
+  }
+
+  setName(name: string): void {
+    this.name = name;
+  }
+}

--- a/src/modules/activity/infrastructure/activity.mapper.ts
+++ b/src/modules/activity/infrastructure/activity.mapper.ts
@@ -1,0 +1,22 @@
+import { Activity as PrismaActivity } from "@prisma/client";
+import { Activity } from "../domain/activity.entity";
+import { ActivityResponseDto } from "../application/activity.response.dto";
+
+export class ActivityMapper {
+  static toDomain(prismaActivity: PrismaActivity): Activity {
+    return new Activity(prismaActivity.id, prismaActivity.name);
+  }
+
+  static toPersistence(activity: Activity): { name: string } {
+    return {
+      name: activity.getName(),
+    };
+  }
+
+  static toResponse(activity: Activity): ActivityResponseDto {
+    return {
+      id: activity.getId() ?? -1,
+      name: activity.getName(),
+    };
+  }
+}

--- a/src/modules/activity/infrastructure/activity.repository.ts
+++ b/src/modules/activity/infrastructure/activity.repository.ts
@@ -1,0 +1,57 @@
+import { Injectable, InternalServerErrorException } from "@nestjs/common";
+import { PrismaService } from "src/prisma/prisma.service";
+import { Activity } from "../domain/activity.entity";
+import { IActivityRepository } from "../domain/activity-repository.interface";
+import { ActivityMapper } from "./activity.mapper";
+
+@Injectable()
+export class PrismaActivityRepository implements IActivityRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async create(activity: Activity): Promise<Activity> {
+    const created = await this.prisma.activity.create({
+      data: ActivityMapper.toPersistence(activity),
+    });
+    return ActivityMapper.toDomain(created);
+  }
+
+  async findAll(): Promise<Activity[]> {
+    const activities = await this.prisma.activity.findMany({
+      orderBy: {
+        id: "asc",
+      },
+    });
+    return activities.map(ActivityMapper.toDomain);
+  }
+
+  async findById(id: number): Promise<Activity | null> {
+    const activity = await this.prisma.activity.findUnique({
+      where: { id },
+    });
+    return activity ? ActivityMapper.toDomain(activity) : null;
+  }
+
+  async findByName(name: string): Promise<Activity | null> {
+    const activity = await this.prisma.activity.findUnique({
+      where: { name },
+    });
+    return activity ? ActivityMapper.toDomain(activity) : null;
+  }
+
+  async update(activity: Activity): Promise<Activity> {
+    const activityId = activity.getId();
+    if (!activityId) {
+      throw new InternalServerErrorException(
+        "Cannot update an activity without an identifier.",
+      );
+    }
+
+    const updated = await this.prisma.activity.update({
+      where: { id: activityId },
+      data: {
+        name: activity.getName(),
+      },
+    });
+    return ActivityMapper.toDomain(updated);
+  }
+}

--- a/src/modules/activity/presentation/activity.controller.ts
+++ b/src/modules/activity/presentation/activity.controller.ts
@@ -1,0 +1,141 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+} from "@nestjs/common";
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from "@nestjs/swagger";
+import { ActivityService } from "../application/activity.service";
+import { CreateActivityRequestDto } from "../application/create-activity.request.dto";
+import { ActivityMapper } from "../infrastructure/activity.mapper";
+import { ActivityResponseDto } from "../application/activity.response.dto";
+import { UpdateActivityDto } from "../application/update-activity.dto";
+
+@ApiTags("activities")
+@Controller("activities")
+export class ActivityController {
+  constructor(private readonly activityService: ActivityService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: "Create a new activity",
+    description: "Registers a new activity in the catalog",
+  })
+  @ApiCreatedResponse({
+    description: "Activity successfully created",
+    type: ActivityResponseDto,
+    schema: {
+      example: { id: 1, name: "Esporte" },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: "Invalid payload",
+    schema: {
+      example: {
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ["Name is required"],
+        error: "Bad Request",
+      },
+    },
+  })
+  @ApiConflictResponse({
+    description: "Activity name already exists",
+    schema: {
+      example: {
+        statusCode: HttpStatus.CONFLICT,
+        message: "Activity name 'Esporte' is already in use.",
+        error: "Conflict",
+      },
+    },
+  })
+  async create(
+    @Body() dto: CreateActivityRequestDto,
+  ): Promise<ActivityResponseDto> {
+    const activity = await this.activityService.create(dto);
+    return ActivityMapper.toResponse(activity);
+  }
+
+  @Get()
+  @ApiOperation({
+    summary: "List activities",
+    description: "Retrieves all registered activities",
+  })
+  @ApiOkResponse({
+    description: "List of activities",
+    type: [ActivityResponseDto],
+    schema: {
+      example: [
+        { id: 1, name: "Esporte" },
+        { id: 2, name: "Artes" },
+      ],
+    },
+  })
+  async findAll(): Promise<ActivityResponseDto[]> {
+    const activities = await this.activityService.findAll();
+    return activities.map(ActivityMapper.toResponse);
+  }
+
+  @Patch(":id")
+  @ApiOperation({
+    summary: "Update an activity",
+    description: "Updates the name of an existing activity",
+  })
+  @ApiOkResponse({
+    description: "Activity successfully updated",
+    type: ActivityResponseDto,
+    schema: {
+      example: { id: 1, name: "Esportes" },
+    },
+  })
+  @ApiBadRequestResponse({
+    description: "Invalid payload",
+    schema: {
+      example: {
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: ["Name is required"],
+        error: "Bad Request",
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: "Activity not found",
+    schema: {
+      example: {
+        statusCode: HttpStatus.NOT_FOUND,
+        message: "Activity with ID 99 not found.",
+        error: "Not Found",
+      },
+    },
+  })
+  @ApiConflictResponse({
+    description: "Activity name already exists",
+    schema: {
+      example: {
+        statusCode: HttpStatus.CONFLICT,
+        message: "Activity name 'Artes' is already in use.",
+        error: "Conflict",
+      },
+    },
+  })
+  async update(
+    @Param("id", ParseIntPipe) id: number,
+    @Body() dto: UpdateActivityDto,
+  ): Promise<ActivityResponseDto> {
+    const activity = await this.activityService.update(id, dto);
+    return ActivityMapper.toResponse(activity);
+  }
+}


### PR DESCRIPTION
### Description
Adds an Activities module that lets authenticated clients create, list, and update activity records while enforcing name validation and uniqueness.

### Related Issue
n/a 

### Type of Change
**(activity management module)**
- New feature 
- Tests
- Documentation

### What's New
Feature: Activity domain/service layer with create/list/update use cases and validation
Changed: Prisma-backed repository + controller exposing POST/GET/PATCH with Swagger docs
Documentation updated: Added docs/API_ATIVIDADES.md covering endpoints.

### Additional Notes
Prisma client regenerated (yarn prisma generate)
