### PR TITLE
fix(env): add missing FIREBASE_STORAGE_BUCKET env variable to GitHub …

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -52,6 +52,7 @@ jobs:
             echo "FIREBASE_PRIVATE_KEY=${{ secrets.FIREBASE_PRIVATE_KEY }}" >> .env.production
             echo "DOMAIN=${{ secrets.DOMAIN }}" >> .env.production
             echo "EMAIL=${{ secrets.EMAIL }}" >> .env.production
+            echo "FIREBASE_STORAGE_BUCKET=${{ secrets.FIREBASE_STORAGE_BUCKET }}" >> .env.production
             mkdir -p nginx-conf web-root dhparam
             if [ ! -f dhparam/dhparam-2048.pem ]; then
               openssl dhparam -out dhparam/dhparam-2048.pem 2048


### PR DESCRIPTION
# …Actions

## Description
A small fix to the GitHub Actions configuration. Added the `FIREBASE_STORAGE_BUCKET` environment variable to the workflow file to ensure proper Firebase integration during CI/CD runs.

## Related Issue
N/A

## Type of Change

<!-- Check all that apply -->
- [ ] New feature  
- [x] Bug fix  
- [ ] Chore  
- [ ] Tests  
- [ ] Documentation  
- [x] CI Change  
- [ ] Performance Improvement  
- [ ] Refactor  
- [ ] Build may be affected  

## What's New

- [ ] Feature A implemented  

## Changed

- [x] Added `FIREBASE_STORAGE_BUCKET` environment variable to GitHub Actions workflow file  

## Removed

- [ ] Deleted feature C  
